### PR TITLE
Fix Swagger example not using actual values for chains

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -59,7 +59,7 @@ export const BlockchainSchema = z.object({
             name: 'chain',
             in: 'path',
         },
-        example: 'EOS',
+        examples: supportedChains,
     })
 });
 


### PR DESCRIPTION
Modify the hardcoded 'EOS' example to the array of `supportedChains` for Swagger to detect the right value to use in the examples.

Closes #27 